### PR TITLE
fix(installCore): write out proper error obj

### DIFF
--- a/customizeUtils/bin/installCore.mjs
+++ b/customizeUtils/bin/installCore.mjs
@@ -9,7 +9,7 @@ function main() {
   try {
     process.stdout.write(execFileSync("npm", ["install", `${CoreDirPath}/`]));
   } catch (err) {
-    process.stderr.write(err.stderr);
+    process.stderr.write(String(err));
     process.exit(1);
   }
 }


### PR DESCRIPTION
Related: #1

Fixes a typo in logging out command errors.